### PR TITLE
Lepší notace u věty o konvergenci

### DIFF
--- a/Chapters/01-metricke-prostory.tex
+++ b/Chapters/01-metricke-prostory.tex
@@ -91,9 +91,9 @@ $\|\textbf{u}\| = \sqrt{\textbf{uu}}$ a vzdáleností $d(\textbf{u},\textbf{v}) 
 		Podle definice konvergence posloupnosti existuje $n_0$ takové, že pro $n \ge n_0$ je $d_1(x_n,x) < \delta$. Tedy je-li $n \ge n_0$
 		máme $d_2(f(x_n),f(x)) < \varepsilon$ a potom $\lim_n f(x_n) = f(\lim_n x_n)$.
 		\item[$\lnot \Rightarrow  \lnot$] Nechť $f$ není spojitá.
-		Potom existují $x \in X_1$ a $\varepsilon_0 > 0$ takové, že pro každé $\delta > 0$ existuje $x_\delta$ takové, že
-		$$d_1(x, x_\delta) < \delta \qquad \text{ale} \qquad d_2(f(x), f(x_\delta)) \ge \varepsilon_0$$
-		Položme $x_n = x_{1/n}$. Potom $\lim_n x_n = x$ ale $(f(x_n))_n$ nemůže konvergovat k $f(x)$.
+		Potom existují $x \in X_1$ a $\varepsilon_0 > 0$ takové, že pro každé $\delta > 0$ existuje $x_\delta := g(\delta)$ takové, že
+		$$d_1(x, g(\delta)) < \delta \qquad \text{ale} \qquad d_2(f(x), f(g(\delta))) \ge \varepsilon_0$$
+		Položme $x_n = g(1/n)$. Potom $\lim_n x_n = x$ ale $(f(x_n))_n$ nemůže konvergovat k $f(x)$.
 	\end{itemize}
 \end{proof}
 

--- a/Chapters/01-metricke-prostory.tex
+++ b/Chapters/01-metricke-prostory.tex
@@ -91,9 +91,9 @@ $\|\textbf{u}\| = \sqrt{\textbf{uu}}$ a vzdáleností $d(\textbf{u},\textbf{v}) 
 		Podle definice konvergence posloupnosti existuje $n_0$ takové, že pro $n \ge n_0$ je $d_1(x_n,x) < \delta$. Tedy je-li $n \ge n_0$
 		máme $d_2(f(x_n),f(x)) < \varepsilon$ a potom $\lim_n f(x_n) = f(\lim_n x_n)$.
 		\item[$\lnot \Rightarrow  \lnot$] Nechť $f$ není spojitá.
-		Potom existují $x \in X_1$ a $\varepsilon_0 > 0$ takové, že pro každé $\delta > 0$ existuje $x_\delta := g(\delta)$ takové, že
-		$$d_1(x, g(\delta)) < \delta \qquad \text{ale} \qquad d_2(f(x), f(g(\delta))) \ge \varepsilon_0$$
-		Položme $x_n = g(1/n)$. Potom $\lim_n x_n = x$ ale $(f(x_n))_n$ nemůže konvergovat k $f(x)$.
+		Potom existují $x \in X_1$ a $\varepsilon_0 > 0$ takové, že pro každé $\delta > 0$ existuje $y(\delta)$ takové, že
+		$$d_1(x, y(\delta)) < \delta \qquad \text{ale} \qquad d_2(f(x), f(y(\delta))) \ge \varepsilon_0$$
+		Položme $x_n = y(1/n)$. Potom $\lim_n x_n = x$ ale $(f(x_n))_n$ nemůže konvergovat k $f(x)$.
 	\end{itemize}
 \end{proof}
 


### PR DESCRIPTION
Když se použije Pultrova původní notace $x(\frac1n)$, vypadá to jako násobení, když se použije spodní index, vypadá to, jako by člověk tvrdil, že $n$-tý prvek posloupnosti se má rovnat $\frac1n$-tému, což je ještě víc matoucí. Proto navrhuji zavést nový funkční symbol a byť to není notace kdovíjak pěkná, alespoň je to jednoznačné.

Budu rád, když klidně dokonvergujeme k ještě lepší úplně jiné notaci, ale na tomhle se pravidelně pálí úplně každej, kdo ty skripta (Pultrovy nebo tyhle) čte. Taky by mohla pomoct alespoň poznámka pod čarou ve smyslu "bacha, tohle není pořadí v posloupnosti, ale $x_\delta$", přičemž s touhle poznámkou je možná i lepší Pultrova notace. 