### PR TITLE
Oprava definice spojité fuknce.

### DIFF
--- a/Chapters/01-metricke-prostory.tex
+++ b/Chapters/01-metricke-prostory.tex
@@ -44,7 +44,7 @@ $\|\textbf{u}\| = \sqrt{\textbf{uu}}$ a vzdáleností $d(\textbf{u},\textbf{v}) 
 
 \begin{definition}[Spojité zobrazení]
 	$f \colon (X,d) \to (Y, d')$ je spojité zobrazení, pokud
-	\[ \forall x, y \in X, \forall \varepsilon > 0 \exists \delta > 0:
+	\[ \forall x \in X, \forall \varepsilon > 0 \exists \delta > 0 \forall y \in X:
 	d(x,y) < \delta \Rightarrow d'(f(x), f(y)) < \varepsilon \]
 \end{definition}
 


### PR DESCRIPTION
V definici spojité funkce jsem přesunul kvantifikátor přes $y$ až za kvantifikaci přes $\delta$.
To je potřeba, jinak je definice rozbitá a splňuje ji každá funkce -- stačí nastavit $\delta = d(x,y)/2$ a implikace je triviálně spněna, jelikož $d(x,y) < \delta$ nikdy neplatí.